### PR TITLE
Add utility contract endpoint and simple web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,27 @@ environment under the project directory on first use.
 # Execute the 'hello' entrypoint of utility 'myutil' inside ./my_project
 python -m orchestrator_core.cli execute ./my_project --utility myutil --entrypoint hello --params_json '{"name": "World"}'
 ```
+
+## Web UI (new)
+
+A minimal React-based frontend is included under `webui/`.
+Launch a simple HTTP server and open the page in your browser:
+
+```bash
+cd webui
+python -m http.server 3000
+# Visit http://localhost:3000
+```
+
+The landing page asks *"What do you want to build?"*. After submitting a
+prompt, it calls the `/plan` API and lists the utilities found. Clicking a
+utility fetches its contract from the new `/utility/{name}` endpoint.
+
+## New API Endpoint
+
+The API now exposes `GET /utility/{name}` to retrieve a utility contract by
+name.
+
+```bash
+curl http://127.0.0.1:8000/utility/myutil
+```

--- a/orchestrator_core/api/main.py
+++ b/orchestrator_core/api/main.py
@@ -63,3 +63,21 @@ def scaffold_project_endpoint(payload: dict):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error scaffolding project: {e}")
     return {"project_path": str(project_path)}
+
+
+@app.get("/utility/{name}")
+def get_utility_contract(name: str):
+    """Return the contract for a named utility.
+
+    Parameters
+    ----------
+    name: str
+        Name of the utility contract to retrieve.
+    """
+    from orchestrator_core.catalog.index import load_specs
+
+    specs = load_specs()
+    spec = specs.get(name)
+    if spec is None:
+        raise HTTPException(status_code=404, detail="Utility not found")
+    return spec

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+from orchestrator_core.api.main import app
+
+
+def test_get_utility_found(monkeypatch):
+    mock_specs = {"foo": {"name": "foo", "version": "1.0.0"}}
+    monkeypatch.setattr(
+        "orchestrator_core.catalog.index.load_specs", lambda: mock_specs
+    )
+    client = TestClient(app)
+    response = client.get("/utility/foo")
+    assert response.status_code == 200
+    assert response.json() == {"name": "foo", "version": "1.0.0"}
+
+
+def test_get_utility_not_found(monkeypatch):
+    monkeypatch.setattr("orchestrator_core.catalog.index.load_specs", lambda: {})
+    client = TestClient(app)
+    response = client.get("/utility/bar")
+    assert response.status_code == 404

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PrometheusBlocks WebUI</title>
+    <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <style>
+      body {
+        background: #121212;
+        color: #fff;
+        font-family: Arial, sans-serif;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: column;
+        min-height: 100vh;
+        margin: 0;
+      }
+      input {
+        padding: 8px;
+        width: 300px;
+        background: #333;
+        color: #fff;
+        border: 1px solid #555;
+      }
+      button {
+        margin-left: 8px;
+        padding: 8px 12px;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+      }
+      li {
+        margin-top: 8px;
+      }
+      .link-button {
+        background: none;
+        border: none;
+        color: #4da3ff;
+        cursor: pointer;
+        text-decoration: underline;
+        font-size: 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      function App() {
+        const [prompt, setPrompt] = React.useState('');
+        const [utilities, setUtilities] = React.useState([]);
+        const [error, setError] = React.useState('');
+
+        const handleSubmit = async (e) => {
+          e.preventDefault();
+          setError('');
+          setUtilities([]);
+          try {
+            const res = await fetch('/plan', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ prompt }),
+            });
+            if (!res.ok) throw new Error('Planning failed');
+            const data = await res.json();
+            let utils = [];
+            if (Array.isArray(data)) {
+              utils = data.map((s) => s.action);
+            } else if (data && Array.isArray(data.resolved)) {
+              utils = data.resolved;
+            }
+            setUtilities(utils);
+          } catch (err) {
+            setError(err.toString());
+          }
+        };
+
+        const fetchContract = async (name) => {
+          try {
+            const res = await fetch(`/utility/${name}`);
+            if (!res.ok) throw new Error('Utility not found');
+            const contract = await res.json();
+            alert(JSON.stringify(contract, null, 2));
+          } catch (err) {
+            alert(err.toString());
+          }
+        };
+
+        return (
+          <div>
+            <h1>What do you want to build?</h1>
+            <form onSubmit={handleSubmit}>
+              <input
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+              />
+              <button type="submit">Plan</button>
+            </form>
+            {error && <p style={{ color: 'red' }}>{error}</p>}
+            <ul>
+              {utilities.map((u) => (
+                <li key={u}>
+                  <button
+                    className="link-button"
+                    onClick={() => fetchContract(u)}
+                  >
+                    {u}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      }
+
+      ReactDOM.render(<App />, document.getElementById('root'));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `/utility/{name}` API route to return contracts
- create minimal React web interface under `webui/`
- document Web UI usage and new endpoint in README
- include tests for the new API route

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `python scripts/token_check.py`