### PR TITLE
Serve web UI from API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,17 +129,16 @@ python -m orchestrator_core.cli execute ./my_project --utility myutil --entrypoi
 ## Web UI (new)
 
 A minimal React-based frontend is included under `webui/`.
-Launch a simple HTTP server and open the page in your browser:
+The API server now serves this UI directly. Start the app with:
 
 ```bash
-cd webui
-python -m http.server 3000
-# Visit http://localhost:3000
+uvicorn orchestrator_core.api.main:app --reload
+# Visit http://localhost:8000
 ```
 
 The landing page asks *"What do you want to build?"*. After submitting a
 prompt, it calls the `/plan` API and lists the utilities found. Clicking a
-utility fetches its contract from the new `/utility/{name}` endpoint.
+utility fetches its contract from the `/utility/{name}` endpoint.
 
 ## New API Endpoint
 

--- a/orchestrator_core/api/main.py
+++ b/orchestrator_core/api/main.py
@@ -1,6 +1,19 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from pathlib import Path
+
+WEBUI_DIR = Path(__file__).resolve().parents[2] / "webui"
 
 app = FastAPI()
+
+
+@app.get("/")
+def serve_webui():
+    """Serve the Web UI index page."""
+    index_file = WEBUI_DIR / "index.html"
+    if not index_file.exists():
+        raise HTTPException(status_code=404, detail="Web UI not found")
+    return FileResponse(index_file)
 
 
 @app.post("/plan")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,3 +19,10 @@ def test_get_utility_not_found(monkeypatch):
     client = TestClient(app)
     response = client.get("/utility/bar")
     assert response.status_code == 404
+
+
+def test_root_serves_webui(tmp_path):
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "PrometheusBlocks WebUI" in response.text


### PR DESCRIPTION
## Summary
- serve the React web UI directly from the FastAPI app
- update README instructions for running the combined server
- test that the root path returns the web UI

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*