### PR TITLE
Add UI parser for execution plan

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <title>PrometheusBlocks WebUI</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
@@ -10,7 +14,7 @@
       body {
         background: #121212;
         color: #fff;
-        font-family: Arial, sans-serif;
+        font-family: 'Roboto', Arial, sans-serif;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -44,6 +48,20 @@
         text-decoration: underline;
         font-size: 1em;
       }
+      .utility-card {
+        background: #1e1e1e;
+        padding: 12px;
+        margin: 10px 0;
+        border-radius: 4px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+        width: 100%;
+        max-width: 600px;
+      }
+      .plan-text {
+        font-family: 'Roboto', Arial, sans-serif;
+        font-size: 1.1em;
+        color: #ddd;
+      }
     </style>
   </head>
   <body>
@@ -53,6 +71,7 @@
         const [prompt, setPrompt] = React.useState('');
         const [plan, setPlan] = React.useState(null);
         const [utilities, setUtilities] = React.useState([]);
+        const [proposed, setProposed] = React.useState([]);
         const [contracts, setContracts] = React.useState({});
         const [error, setError] = React.useState('');
 
@@ -61,6 +80,7 @@
           setError('');
           setUtilities([]);
           setContracts({});
+          setProposed([]);
           setPlan(null);
           try {
             const res = await fetch('/plan', {
@@ -78,6 +98,9 @@
               utils = data.resolved;
             }
             setUtilities(utils);
+            if (data && Array.isArray(data.proposed_utilities)) {
+              setProposed(data.proposed_utilities);
+            }
           } catch (err) {
             setError(err.toString());
           }
@@ -109,6 +132,7 @@
             {plan && (
               <div>
                 <h2>Execution Plan</h2>
+                {plan.plan && <p className="plan-text">{plan.plan}</p>}
                 <pre style={{ whiteSpace: 'pre-wrap' }}>
                   {JSON.stringify(plan, null, 2)}
                 </pre>
@@ -135,6 +159,29 @@
                 </li>
               ))}
             </ul>
+            {proposed.length > 0 && (
+              <div style={{ width: '100%', maxWidth: '600px' }}>
+                <h2>Proposed Utilities</h2>
+                {proposed.map((u) => (
+                  <div key={u.name} className="utility-card">
+                    <h3>{u.name}</h3>
+                    <p>{u.description}</p>
+                    {u.entrypoints && (
+                      <div>
+                        <strong>Entrypoints:</strong>
+                        <ul>
+                          {u.entrypoints.map((ept) => (
+                            <li key={ept.name}>
+                              {ept.name}: {ept.description}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         );
       }


### PR DESCRIPTION
## Summary
- use Roboto font for the web UI
- parse plan JSON in the web UI and display plan text
- show proposed utilities as cards with descriptions and entrypoints

## Testing
- `pytest -q` *(fails: command not found)*