### PR TITLE
Add scaffold button and git initialization

### DIFF
--- a/orchestrator_core/executor/scaffolder.py
+++ b/orchestrator_core/executor/scaffolder.py
@@ -41,6 +41,19 @@ def clone_repository(
         return False
 
 
+def init_git_repo(repo_dir: Path) -> bool:
+    """Initialize a git repository in the given directory."""
+    try:
+        subprocess.run(["git", "init"], cwd=repo_dir, check=True)
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to initialize git repo in {repo_dir}: {e}")
+        return False
+    except Exception as e:  # pragma: no cover - unexpected errors
+        logger.error(f"Unexpected error during git init in {repo_dir}: {e}")
+        return False
+
+
 def customize_new_utility_from_template(template_dir: Path, new_utility_name: str):
     """
     Customize a generic block template in template_dir for a new utility named new_utility_name.
@@ -132,6 +145,7 @@ def scaffold_project(
             logger.error(f"Failed to clone resolved utility '{util}' from {repo_url}")
         else:
             logger.info(f"Successfully cloned resolved utility '{util}'")
+            init_git_repo(util_dir)
     # Handle missing utilities (scaffold new)
     for util in plan.get("missing", []):
         util_dir = main_project_path / util
@@ -144,4 +158,5 @@ def scaffold_project(
             continue
         customize_new_utility_from_template(util_dir, util)
         logger.info(f"Successfully scaffolded missing utility '{util}'")
+        init_git_repo(util_dir)
     return main_project_path

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -89,6 +89,12 @@ def test_scaffold_project_calls(monkeypatch, tmp_path):
     monkeypatch.setattr(
         scaffolder, "customize_new_utility_from_template", fake_customize
     )
+
+    def fake_init(repo_dir):
+        calls.append(("init", str(repo_dir)))
+        return True
+
+    monkeypatch.setattr(scaffolder, "init_git_repo", fake_init)
     # Run scaffolding
     project_path = scaffolder.scaffold_project(plan, base, project_name, template_url)
     # Verify returned path
@@ -102,3 +108,5 @@ def test_scaffold_project_calls(monkeypatch, tmp_path):
     ) in calls
     assert ("clone", template_url, str(base / project_name / "b"), None) in calls
     assert ("customize", str(base / project_name / "b"), "b") in calls
+    assert ("init", str(base / project_name / "a")) in calls
+    assert ("init", str(base / project_name / "b")) in calls

--- a/webui/index.html
+++ b/webui/index.html
@@ -209,6 +209,7 @@
         const [contracts, setContracts] = React.useState({});
         const [error, setError] = React.useState('');
         const [stage, setStage] = React.useState('input');
+        const [scaffolded, setScaffolded] = React.useState(false);
         const textareaRef = React.useRef(null);
 
         const handleSubmit = async (e) => {
@@ -218,6 +219,7 @@
           setContracts({});
           setProposed([]);
           setPlan(null);
+          setScaffolded(false);
           setStage('loading');
           try {
             const res = await fetch('/plan', {
@@ -257,6 +259,33 @@
           } catch (err) {
             setContracts((c) => ({ ...c, [name]: { error: err.toString() } }));
           }
+        };
+
+        const handleScaffold = async () => {
+          const projectName = prompt('Project folder name?', 'my_project');
+          if (!projectName) return;
+          const baseDir = prompt('Base directory on server', '.');
+          try {
+            const res = await fetch('/scaffold_project', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                plan,
+                project_name: projectName,
+                output_base_dir: baseDir,
+                template_url: 'https://github.com/PrometheusBlocks/block-template.git',
+              }),
+            });
+            if (!res.ok) throw new Error('Scaffolding failed');
+            await res.json();
+            setScaffolded(true);
+          } catch (err) {
+            alert(err.toString());
+          }
+        };
+
+        const handleCreateBlocks = () => {
+          alert("You're almost there!");
         };
 
         return (
@@ -305,6 +334,14 @@
                       <ProposedCard key={u.name} util={u} />
                     ))}
                   </div>
+                )}
+                <button onClick={handleScaffold} style={{ marginTop: '16px' }}>
+                  Scaffold Plan
+                </button>
+                {scaffolded && (
+                  <button onClick={handleCreateBlocks} style={{ marginTop: '8px' }}>
+                    Create the blocks
+                  </button>
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- add `init_git_repo` helper in scaffolder and call it after cloning utilities
- update executor tests for git init calls
- enhance web UI: Scaffold Plan button triggers `/scaffold_project` then shows Create the blocks button

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*