### PR TITLE
Add GitHub repo creation to scaffolder

### DIFF
--- a/orchestrator_core/api/main.py
+++ b/orchestrator_core/api/main.py
@@ -66,13 +66,22 @@ def scaffold_project_endpoint(payload: dict):
     template_url = payload.get("template_url")
     if not template_url or not isinstance(template_url, str):
         template_url = "https://github.com/PrometheusBlocks/block-template.git"
+    create_repos = bool(payload.get("create_github_repos"))
+    github_org = payload.get("github_org")
     # Perform scaffolding
     from pathlib import Path
     from orchestrator_core.executor.scaffolder import scaffold_project
 
     try:
         base_path = Path(output_dir)
-        project_path = scaffold_project(plan, base_path, project_name, template_url)
+        project_path = scaffold_project(
+            plan,
+            base_path,
+            project_name,
+            template_url,
+            create_github_repos=create_repos,
+            github_org=github_org,
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error scaffolding project: {e}")
     return {"project_path": str(project_path)}

--- a/orchestrator_core/cli.py
+++ b/orchestrator_core/cli.py
@@ -73,6 +73,16 @@ def main(argv=None) -> None:
         help="Generic block template repository URL",
     )
     scaffold_p.add_argument(
+        "--create-github-repos",
+        action="store_true",
+        help="Create GitHub repositories for new utilities",
+    )
+    scaffold_p.add_argument(
+        "--github-org",
+        default=None,
+        help="GitHub organization to create repos in (default: user)",
+    )
+    scaffold_p.add_argument(
         "project_name",
         help="Name of the project directory to create",
     )
@@ -169,6 +179,8 @@ def main(argv=None) -> None:
             Path(args.outdir),
             args.project_name,
             args.template_url,
+            create_github_repos=args.create_github_repos,
+            github_org=args.github_org,
         )
         # Overwrite placeholder contracts with full specs from proposed_utilities
         if proposed_contracts:

--- a/webui/index.html
+++ b/webui/index.html
@@ -232,6 +232,7 @@
         const [showDialog, setShowDialog] = React.useState(false);
         const [projectNameInput, setProjectNameInput] = React.useState('my_project');
         const [baseDirInput, setBaseDirInput] = React.useState('.');
+        const [createRepos, setCreateRepos] = React.useState(true);
         const textareaRef = React.useRef(null);
 
         const handleSubmit = async (e) => {
@@ -295,6 +296,7 @@
                 project_name: projectName,
                 output_base_dir: baseDir,
                 template_url: 'https://github.com/PrometheusBlocks/block-template.git',
+                create_github_repos: createRepos,
               }),
             });
             if (!res.ok) throw new Error('Scaffolding failed');
@@ -388,6 +390,16 @@
                             value={baseDirInput}
                             onChange={(e) => setBaseDirInput(e.target.value)}
                           />
+                        </label>
+                      </div>
+                      <div style={{ marginTop: '8px' }}>
+                        <label>
+                          <input
+                            type="checkbox"
+                            checked={createRepos}
+                            onChange={(e) => setCreateRepos(e.target.checked)}
+                          />
+                          Create GitHub Repos
                         </label>
                       </div>
                       <div style={{ marginTop: '12px', textAlign: 'right' }}>


### PR DESCRIPTION
## Summary
- optionally create and push GitHub repositories for newly scaffolded utilities
- expose options via CLI, API and Web UI
- add checkbox in web UI dialog to toggle repo creation
- update tests for scaffolder to cover new behaviour

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*