### PR TITLE
Fix web UI planning display and scaffold handling

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from orchestrator_core.api.main import app
+from orchestrator_core.api.main import app, normalize_plan_for_scaffolding
 
 
 def test_get_utility_found(monkeypatch):
@@ -26,3 +26,36 @@ def test_root_serves_webui(tmp_path):
     response = client.get("/")
     assert response.status_code == 200
     assert "PrometheusBlocks WebUI" in response.text
+
+
+def test_normalize_plan_list(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator_core.api.main.load_specs", lambda: {"foo": {}, "bar": {}}
+    )
+    raw = [
+        {"step_id": 1, "action": "foo"},
+        {"step_id": 2, "action": "baz"},
+    ]
+    norm = normalize_plan_for_scaffolding(raw)
+    assert norm == {"resolved": ["foo"], "missing": ["baz"]}
+
+
+def test_normalize_plan_proposed(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator_core.api.main.load_specs", lambda: {"foo": {}, "bar": {}}
+    )
+    raw = {"proposed_utilities": [{"name": "foo"}, {"name": "qux"}]}
+    norm = normalize_plan_for_scaffolding(raw)
+    assert norm == {"resolved": ["foo"], "missing": ["qux"]}
+
+
+def test_normalize_plan_caps(monkeypatch):
+    monkeypatch.setattr(
+        "orchestrator_core.api.main.load_specs", lambda: {"cap_a": {}}
+    )
+    raw = {
+        "used_capabilities": ["cap_a"],
+        "missing_capabilities": ["cap_b"],
+    }
+    norm = normalize_plan_for_scaffolding(raw)
+    assert norm == {"resolved": ["cap_a"], "missing": ["cap_b"]}

--- a/webui/index.html
+++ b/webui/index.html
@@ -260,6 +260,14 @@
               utils = data.resolved.map((r) =>
                 typeof r === 'string' ? r : r.name
               );
+            } else if (data && Array.isArray(data.used_capabilities)) {
+              utils = data.used_capabilities.map((r) =>
+                typeof r === 'string' ? r : r.name
+              );
+            } else if (data && Array.isArray(data.proposed_utilities)) {
+              utils = data.proposed_utilities
+                .map((u) => u.name)
+                .filter(Boolean);
             }
             setUtilities(utils);
             if (data && Array.isArray(data.proposed_utilities)) {


### PR DESCRIPTION
## Summary
- normalize planner output before scaffolding projects
- extend web UI to parse modern plan formats
- add tests for new plan normalization helper

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*